### PR TITLE
fix quoting of variable for shared folder

### DIFF
--- a/usr/sbin/omv-showsharedfolder
+++ b/usr/sbin/omv-showsharedfolder
@@ -4,7 +4,7 @@
 
 OMV_CONFIG_FILE="/etc/openmediavault/config.xml"
 
-search=$1
+search="$1"
 
 # Check for empty search string
 if [ -z "${search}" ]; then

--- a/usr/share/openmediavault/engined/rpc/resetperms.inc
+++ b/usr/share/openmediavault/engined/rpc/resetperms.inc
@@ -64,7 +64,7 @@ class OMVRpcServiceResetPerms extends \OMV\Rpc\ServiceAbstract
             $sfpath = rtrim($sfpath, '/');
             $objectv->add('path', 'string', $sfpath);
             $output = [];
-            $cmd = sprintf("omv-showsharedfolder %s", $objectv->get('name'));
+            $cmd = sprintf('omv-showsharedfolder "%s"', $objectv->get('name'));
             exec($cmd, $output);
             $objectv->add('inuse', 'string', implode('<br/>', $output));
             if (is_dir($sfpath)) {


### PR DESCRIPTION
This PR fixes the quoting of the variable for shared folders.

Although I know that OpenMediaVault currently doesn't support spaces in shared folder names, this fix is necessary for users who may have patched their OMV source to allow such names (as I’ve done in my current OMV installation).

For all regular users, this PR introduces no regressions.

I’d appreciate it if you could consider merging it.

Note: I plan to review more plugins and create further patches to improve quoting and support for variables containing spaces.